### PR TITLE
Use relative imports + add dependencies

### DIFF
--- a/ccCluster/ccCluster.py
+++ b/ccCluster/ccCluster.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 __author__ = "Gianluca Santoni"
 __copyright__ = "Copyright 20150-2019"
@@ -21,7 +21,7 @@ import subprocess
 
 #import ccCluster classes
 
-from clustering import Clustering
+from .clustering import Clustering
 
 
 # Insert parse  to change the file path from command line

--- a/ccCluster/ccCluster_gui.py
+++ b/ccCluster/ccCluster_gui.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 __author__ = "Gianluca Santoni"
 __copyright__ = "Copyright 20150-2019"
@@ -32,9 +32,9 @@ from time import sleep
 import os
 
 
-from resultsTab import resultsTab
-from summary import resultsSummary
-from clustering import Clustering
+from .resultsTab import resultsTab
+from .summary import resultsSummary
+from .clustering import Clustering
 #import CalcClass
 
 # Insert parse  to change the file path from command line

--- a/ccCluster/summary.py
+++ b/ccCluster/summary.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 __author__ = "Gianluca Santoni"
 __copyright__ = "Copyright 20150-2019"
 __credits__ = ["Gianluca Santoni, Alexander Popov"]
@@ -12,7 +12,7 @@ __status__ = "Beta"
 from PyQt5 import QtGui, QtCore, QtWidgets
 import os, sys
 
-from textSummary import generateLogSummary
+from .textSummary import generateLogSummary
 #a class to generate the results widget.
 #will be used as a tab in the main window
 

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,16 @@ setup(name="ccCLuster",
       description='Hierarchical cluster analysis for MX',
       author='Gianluca Santoni',
       packages=["ccCluster"],
-      scripts=['ccCluster/ccCalc.py', 'ccCluster/ccCluster.py']
+      setup_requires=['setuptools'],
+      install_requires=[
+          'numpy',
+          'scipy',
+          'pathos',
+          'matplotlib',
+          'PyQt5'],  # TODO: iotbx, cctbx
+      entry_points={
+          'console_scripts': [
+              'ccCalc = ccCluster.ccCalc:main',
+              'ccCluster = ccCluster.ccCluster:main'],
+          },
       )


### PR DESCRIPTION
This PR makes use of relative imports within the package and update `setup.py` to:
- declare build (`setup_requires`) and installation (`install_requires`) dependencies
- declare executable as `entry_points`.

There is an issue with iotbx and cctbx: I couldn't find a package in pypi. Is there any?